### PR TITLE
fix::authにemailを持たせる仕様に変更(実情報 を知り得ない設計は維持)

### DIFF
--- a/src/main/java/com/example/flea_market_app/auth/domain/AuthUser.java
+++ b/src/main/java/com/example/flea_market_app/auth/domain/AuthUser.java
@@ -9,9 +9,10 @@ public class AuthUser {
 
 	private final String userId;
 	private final String passwordHash;
+	private final String identifier;
 
-	public static AuthUser of(String userId, String passwordHash) {
-		return new AuthUser(userId, passwordHash);
+	public static AuthUser of(String userId, String passwordHash, String identifier) {
+		return new AuthUser(userId, passwordHash, identifier);
 	}
 
 }

--- a/src/main/java/com/example/flea_market_app/auth/domain/AuthUserEntity.java
+++ b/src/main/java/com/example/flea_market_app/auth/domain/AuthUserEntity.java
@@ -1,0 +1,35 @@
+package com.example.flea_market_app.auth.domain;
+
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "auth_users")
+@Getter
+@Setter
+public class AuthUserEntity {
+
+	@Id
+	@Column(name = "id", nullable = false)
+	private UUID id;
+
+	@Column(name = "user_id", nullable = false)
+	private UUID userId;
+
+	@Column(name = "email", nullable = false)
+	private String email;
+
+	@Column(name = "password_hash", nullable = false)
+	private String passwordHash;
+
+	@Column(name = "is_admin", nullable = false)
+	private boolean admin;
+
+}

--- a/src/main/java/com/example/flea_market_app/auth/repository/AuthUserRepository.java
+++ b/src/main/java/com/example/flea_market_app/auth/repository/AuthUserRepository.java
@@ -1,0 +1,13 @@
+package com.example.flea_market_app.auth.repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.flea_market_app.auth.domain.AuthUserEntity;
+
+public interface AuthUserRepository extends JpaRepository<AuthUserEntity, UUID> {
+
+	Optional<AuthUserEntity> findByEmail(String email);
+}

--- a/src/main/java/com/example/flea_market_app/auth/service/DbAuthUserProvider.java
+++ b/src/main/java/com/example/flea_market_app/auth/service/DbAuthUserProvider.java
@@ -1,0 +1,28 @@
+package com.example.flea_market_app.auth.service;
+
+import org.springframework.stereotype.Component;
+
+import com.example.flea_market_app.auth.domain.AuthUser;
+import com.example.flea_market_app.auth.domain.AuthUserEntity;
+import com.example.flea_market_app.auth.repository.AuthUserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class DbAuthUserProvider implements AuthUserProvider {
+
+	private final AuthUserRepository authUserRepository;
+
+	@Override
+	public AuthUser loadByIdentifier(String identifier) {
+		AuthUserEntity entity = authUserRepository.findByEmail(identifier)
+				.orElseThrow(() -> new IllegalArgumentException("not found"));
+
+		return AuthUser.of(
+				entity.getUserId().toString(),
+				entity.getPasswordHash(),
+				entity.getEmail());
+	}
+
+}


### PR DESCRIPTION
userなどとの情報の保持の境界を考慮した結果、authで保持する設計に変更しました。
ログイン時にemailを要求する仕様です。